### PR TITLE
chore(format): apply prettier import sorting across non-app packages

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,9 @@
   "useTabs": false,
   "bracketSpacing": true,
   "arrowParens": "avoid",
-  "endOfLine": "lf"
+  "endOfLine": "lf",
+  "plugins": [
+    "@trivago/prettier-plugin-sort-imports",
+    "prettier-plugin-tailwindcss"
+  ]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
 import js from '@eslint/js';
-import globals from 'globals';
-import eslintPluginPrettier from 'eslint-plugin-prettier';
 import eslintConfigPrettier from 'eslint-config-prettier';
+import eslintPluginPrettier from 'eslint-plugin-prettier';
+import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
@@ -29,15 +29,12 @@ export default tseslint.config(
       prettier: eslintPluginPrettier,
     },
     rules: {
-      // Prettier as ESLint rule
       'prettier/prettier': 'error',
-
-      // Basic modern JS rules
       'prefer-const': 'error',
       'no-var': 'error',
-      'no-unused-vars': 'off', // Turn off base rule
-      '@typescript-eslint/no-unused-vars': 'error', // Use TypeScript version
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': 'error',
     },
   },
-  eslintConfigPrettier // This must be last
+  eslintConfigPrettier
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.31.0",
+        "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "@types/jsonwebtoken": "^9.0.10",
         "concurrently": "^8.2.2",
         "eslint": "^9.31.0",
@@ -24,6 +25,7 @@
         "eslint-plugin-prettier": "^5.5.3",
         "globals": "^16.3.0",
         "prettier": "^3.6.2",
+        "prettier-plugin-tailwindcss": "^0.6.14",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.3",
         "typescript": "^5.8.3",
@@ -3314,6 +3316,41 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-5.2.2.tgz",
+      "integrity": "sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.7",
+        "@babel/traverse": "^7.26.7",
+        "@babel/types": "^7.26.7",
+        "javascript-natural-sort": "^0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">18.12"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x",
+        "prettier-plugin-svelte": "3.x",
+        "svelte": "4.x || 5.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -6492,6 +6529,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
@@ -7585,6 +7629,93 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz",
+      "integrity": "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",
+    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/jsonwebtoken": "^9.0.10",
     "concurrently": "^8.2.2",
     "eslint": "^9.31.0",
@@ -37,6 +38,7 @@
     "eslint-plugin-prettier": "^5.5.3",
     "globals": "^16.3.0",
     "prettier": "^3.6.2",
+    "prettier-plugin-tailwindcss": "^0.6.14",
     "rimraf": "^6.0.1",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",

--- a/packages/api/src/api-keys/api-keys.controller.ts
+++ b/packages/api/src/api-keys/api-keys.controller.ts
@@ -1,8 +1,8 @@
 // import z from 'zod';
-import { NextFunction, Request, Response } from 'express';
 import { IApiKeysService } from './api-keys.service';
-import { handleValidationError } from 'src/utils/validation-error.utils';
 import { ApiKeyPublic, uuidSchema } from '@dev-dashboard/shared';
+import { NextFunction, Request, Response } from 'express';
+import { handleValidationError } from 'src/utils/validation-error.utils';
 import z from 'zod';
 
 export const ApiKeysController = (apiKeysService: IApiKeysService) => {

--- a/packages/api/src/api-keys/api-keys.model.ts
+++ b/packages/api/src/api-keys/api-keys.model.ts
@@ -1,3 +1,4 @@
+import { ENV } from '../config/env_variables';
 import {
   DynamoDBDocumentClient,
   GetCommand,
@@ -5,7 +6,6 @@ import {
   QueryCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
-import { ENV } from '../config/env_variables';
 import { ApiKey } from '@dev-dashboard/shared';
 
 const API_KEYS_TABLE = ENV.API_KEYS_TABLE;

--- a/packages/api/src/api-keys/api-keys.route.ts
+++ b/packages/api/src/api-keys/api-keys.route.ts
@@ -1,11 +1,10 @@
-import { Router } from 'express';
-
 import { docClient } from '../config/dynamodb';
-import { ApiKeysService } from './api-keys.service';
 import { ApiKeysController } from './api-keys.controller';
 import { ApiKeysModel } from './api-keys.model';
-import { authorizationMiddleware } from 'src/middlewares/authorization.middleware';
+import { ApiKeysService } from './api-keys.service';
+import { Router } from 'express';
 import { apiKeysMiddleware } from 'src/middlewares/api-keys.middleware';
+import { authorizationMiddleware } from 'src/middlewares/authorization.middleware';
 
 const router = Router();
 

--- a/packages/api/src/api-keys/api-keys.service.ts
+++ b/packages/api/src/api-keys/api-keys.service.ts
@@ -1,9 +1,9 @@
+import { IApiKeysModel } from './api-keys.model';
+import { ApiKey, ApiKeyPublic } from '@dev-dashboard/shared';
 import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
-import { ApiKey, ApiKeyPublic } from '@dev-dashboard/shared';
-import { IApiKeysModel } from './api-keys.model';
-import { UnauthorizedError } from 'src/utils/errors.utils';
 import { ENV } from 'src/config/env_variables';
+import { UnauthorizedError } from 'src/utils/errors.utils';
 
 export interface IApiKeysService {
   create(userId: string, description: string): Promise<ApiKeyPublic>;

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,16 +1,14 @@
-import express from 'express';
-import helmet from 'helmet';
-import rateLimit from 'express-rate-limit';
-import cookieParser from 'cookie-parser';
-
-import authenticationRouter from './auth-related/authentication/authentication.route';
-import todoRouter from './todos/todo.route';
-import userRouter from './user/user.route';
 import apiKeysRouter from './api-keys/api-keys.route';
-
+import authenticationRouter from './auth-related/authentication/authentication.route';
+import { authorizationMiddleware } from './middlewares/authorization.middleware';
 import { errorHandlerMiddleware } from './middlewares/error_handler.middleware';
 import { loggerMiddleware } from './middlewares/logger.middleware';
-import { authorizationMiddleware } from './middlewares/authorization.middleware';
+import todoRouter from './todos/todo.route';
+import userRouter from './user/user.route';
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import helmet from 'helmet';
 
 const app = express();
 

--- a/packages/api/src/auth-related/authentication/authentication.controller.ts
+++ b/packages/api/src/auth-related/authentication/authentication.controller.ts
@@ -1,4 +1,5 @@
-import { NextFunction, Request, Response } from 'express';
+import { ENV } from '../../config/env_variables';
+import { IAuthenticationService } from './authentication.service';
 import {
   AuthenticationLoginRequestPublicSchema,
   AuthenticationRefreshRequestPrivateSchema,
@@ -9,8 +10,7 @@ import {
   authenticationRefreshRequestPrivateSchema,
   authenticationRegisterRequestPublicSchema,
 } from '@dev-dashboard/shared';
-import { IAuthenticationService } from './authentication.service';
-import { ENV } from '../../config/env_variables';
+import { NextFunction, Request, Response } from 'express';
 import { handleValidationError } from 'src/utils/validation-error.utils';
 
 const REFRESH_TOKEN_EXPIRY = 7 * 24 * 60 * 60 * 1000;

--- a/packages/api/src/auth-related/authentication/authentication.route.ts
+++ b/packages/api/src/auth-related/authentication/authentication.route.ts
@@ -1,14 +1,12 @@
-import { Router } from 'express';
-
 import { docClient } from '../../config/dynamodb';
-import { AuthenticationService } from './authentication.service';
-import { AuthenticationController } from './authentication.controller';
-import { IAuthenticationService } from './authentication.service';
-
 import { UserModel } from '../../user/user.model';
-import { RefreshTokenModel } from '../refresh-token/refresh-token.model';
 import { UserService } from '../../user/user.service';
+import { RefreshTokenModel } from '../refresh-token/refresh-token.model';
 import { RefreshTokenService } from '../refresh-token/refresh-token.service';
+import { AuthenticationController } from './authentication.controller';
+import { AuthenticationService } from './authentication.service';
+import { IAuthenticationService } from './authentication.service';
+import { Router } from 'express';
 
 const router = Router();
 

--- a/packages/api/src/auth-related/authentication/authentication.service.ts
+++ b/packages/api/src/auth-related/authentication/authentication.service.ts
@@ -1,5 +1,6 @@
+import { IUserService } from '../../user/user.service';
 import { generateJWT, verifyJWT } from '../../utils/jwt.utils';
-import { bcryptCompare } from 'src/utils/bcrypt.utils';
+import { IRefreshTokenService } from '../refresh-token/refresh-token.service';
 import {
   AuthenticationLoginRequestPublicSchema,
   AuthenticationRefreshRequestPrivateSchema,
@@ -11,8 +12,7 @@ import {
   RefreshTokenRecordAndPlain,
   RefreshToken,
 } from '@dev-dashboard/shared';
-import { IUserService } from '../../user/user.service';
-import { IRefreshTokenService } from '../refresh-token/refresh-token.service';
+import { bcryptCompare } from 'src/utils/bcrypt.utils';
 import {
   ConflictError,
   NotFoundError,

--- a/packages/api/src/auth-related/refresh-token/refresh-token.model.ts
+++ b/packages/api/src/auth-related/refresh-token/refresh-token.model.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ENV } from '../../config/env_variables';
 import {
   DynamoDBDocumentClient,
   PutCommand,
@@ -10,7 +11,6 @@ import {
   UpdateCommand,
   GetCommand,
 } from '@aws-sdk/lib-dynamodb';
-import { ENV } from '../../config/env_variables';
 import { RefreshToken } from '@dev-dashboard/shared';
 
 const REFRESH_TOKENS_TABLE = ENV.REFRESH_TOKENS_TABLE;

--- a/packages/api/src/auth-related/refresh-token/refresh-token.service.ts
+++ b/packages/api/src/auth-related/refresh-token/refresh-token.service.ts
@@ -1,11 +1,11 @@
+import { ENV } from '../../config/env_variables';
+import { ConflictError } from '../../utils/errors.utils';
+import { generateRefreshToken, generateUUID } from '../../utils/uuid.utils';
 import { IRefreshTokenModel } from './refresh-token.model';
 import {
   RefreshToken,
   RefreshTokenRecordAndPlain,
 } from '@dev-dashboard/shared';
-import { ConflictError } from '../../utils/errors.utils';
-import { generateRefreshToken, generateUUID } from '../../utils/uuid.utils';
-import { ENV } from '../../config/env_variables';
 import bcrypt from 'bcryptjs';
 
 export interface IRefreshTokenService {

--- a/packages/api/src/config/dynamodb.ts
+++ b/packages/api/src/config/dynamodb.ts
@@ -1,6 +1,6 @@
+import { ENV } from './env_variables';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { ENV } from './env_variables';
 
 const client = new DynamoDBClient({
   region: ENV.AWS_REGION,

--- a/packages/api/src/config/vitest.d.ts
+++ b/packages/api/src/config/vitest.d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-import 'vitest';
 import { CustomMatcher } from 'aws-sdk-client-mock-vitest';
+import 'vitest';
 
 declare module 'vitest' {
   interface Assertion<T = any> extends CustomMatcher<T> {}

--- a/packages/api/src/middlewares/api-keys.middleware.ts
+++ b/packages/api/src/middlewares/api-keys.middleware.ts
@@ -1,7 +1,7 @@
-import { NextFunction, Request, Response } from 'express';
-import { ApiKeysService } from '../api-keys/api-keys.service';
 import { ApiKeysModel } from '../api-keys/api-keys.model';
+import { ApiKeysService } from '../api-keys/api-keys.service';
 import { docClient } from '../config/dynamodb';
+import { NextFunction, Request, Response } from 'express';
 import { extractBearerToken } from 'src/utils/jwt.utils';
 
 const apiKeysService = ApiKeysService(ApiKeysModel(docClient));

--- a/packages/api/src/middlewares/authorization.middleware.ts
+++ b/packages/api/src/middlewares/authorization.middleware.ts
@@ -1,10 +1,10 @@
-import { NextFunction, Request, Response } from 'express';
+import { docClient } from '../config/dynamodb';
+import { UserModel } from '../user/user.model';
+import { UserService } from '../user/user.service';
 import { UnauthorizedError } from '../utils/errors.utils';
 import { extractBearerToken, verifyJWT } from '../utils/jwt.utils';
 import { AuthorizationTokenPayload } from '@dev-dashboard/shared';
-import { UserService } from '../user/user.service';
-import { UserModel } from '../user/user.model';
-import { docClient } from '../config/dynamodb';
+import { NextFunction, Request, Response } from 'express';
 
 const userService = UserService(UserModel(docClient));
 

--- a/packages/api/src/middlewares/error_handler.middleware.ts
+++ b/packages/api/src/middlewares/error_handler.middleware.ts
@@ -1,11 +1,11 @@
-import { Request, Response, NextFunction } from 'express';
+import { sendError } from '../utils/api.utils';
 import {
   ConflictError,
   NotFoundError,
   UnauthorizedError,
 } from '../utils/errors.utils';
-import { sendError } from '../utils/api.utils';
 import { logger } from './logger.middleware';
+import { Request, Response, NextFunction } from 'express';
 
 export const errorHandlerMiddleware = (
   error: unknown,

--- a/packages/api/src/todos/todo.controller.ts
+++ b/packages/api/src/todos/todo.controller.ts
@@ -1,13 +1,13 @@
-import z from 'zod';
-import { NextFunction, Request, Response } from 'express';
+import { ITodoService } from './interfaces/itodo.service';
 import {
   createResolutionSchema,
   rawTodoBatchSchema,
   uuidSchema,
   VALIDATION_CONSTANTS,
 } from '@dev-dashboard/shared';
+import { NextFunction, Request, Response } from 'express';
 import { handleValidationError } from 'src/utils/validation-error.utils';
-import { ITodoService } from './interfaces/itodo.service';
+import z from 'zod';
 
 export const TodoController = (todoService: ITodoService) => {
   return {

--- a/packages/api/src/todos/todo.model.ts
+++ b/packages/api/src/todos/todo.model.ts
@@ -1,12 +1,12 @@
+import { ENV } from '../config/env_variables';
+import { ITodoModel } from './interfaces/itodo.model';
 import {
   DynamoDBDocumentClient,
   PutCommand,
   QueryCommand,
   BatchWriteCommand,
 } from '@aws-sdk/lib-dynamodb';
-import { ENV } from '../config/env_variables';
 import { ProjectNames, TodoBatch, TodoResolution } from '@dev-dashboard/shared';
-import { ITodoModel } from './interfaces/itodo.model';
 
 const BATCHES_TABLE = ENV.TODO_BATCHES_TABLE;
 const RESOLUTIONS_TABLE = ENV.TODO_RESOLUTIONS_TABLE;

--- a/packages/api/src/todos/todo.route.ts
+++ b/packages/api/src/todos/todo.route.ts
@@ -1,9 +1,8 @@
-import { Router } from 'express';
-
 import { docClient } from '../config/dynamodb';
+import { TodoController } from './todo.controller';
 import { TodoModel } from './todo.model';
 import { TodoService } from './todo.service';
-import { TodoController } from './todo.controller';
+import { Router } from 'express';
 import { apiKeysMiddleware } from 'src/middlewares/api-keys.middleware';
 import { authorizationMiddleware } from 'src/middlewares/authorization.middleware';
 

--- a/packages/api/src/todos/todo.service.ts
+++ b/packages/api/src/todos/todo.service.ts
@@ -1,6 +1,6 @@
-import crypto from 'crypto';
 import { generateUUID } from '../utils/uuid.utils';
 import { ITodoModel } from './interfaces/itodo.model';
+import { ComparisonResult, ITodoService } from './interfaces/itodo.service';
 import {
   TodoMeta,
   TodoBatch,
@@ -12,7 +12,7 @@ import {
   TodoResolution,
   CreateResolution,
 } from '@dev-dashboard/shared';
-import { ComparisonResult, ITodoService } from './interfaces/itodo.service';
+import crypto from 'crypto';
 
 const buildTodosInfoResponse = (
   userId: string,

--- a/packages/api/src/user/user.controller.ts
+++ b/packages/api/src/user/user.controller.ts
@@ -1,10 +1,10 @@
-import { NextFunction, Request, Response } from 'express';
 import { IUserService } from './user.service';
 import {
   passwordUpdateSchema,
   uuidSchema,
   userUpdateSchema,
 } from '@dev-dashboard/shared';
+import { NextFunction, Request, Response } from 'express';
 import { handleValidationError } from 'src/utils/validation-error.utils';
 
 export interface IUserController {

--- a/packages/api/src/user/user.model.ts
+++ b/packages/api/src/user/user.model.ts
@@ -1,3 +1,4 @@
+import { ENV } from '../config/env_variables';
 import {
   DeleteCommand,
   DynamoDBDocumentClient,
@@ -6,7 +7,6 @@ import {
   TransactWriteCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
-import { ENV } from '../config/env_variables';
 import { User } from '@dev-dashboard/shared';
 
 const USERS_TABLE = ENV.USERS_TABLE;

--- a/packages/api/src/user/user.route.ts
+++ b/packages/api/src/user/user.route.ts
@@ -1,9 +1,8 @@
-import { Router } from 'express';
-
 import { docClient } from '../config/dynamodb';
+import { UserController } from './user.controller';
 import { IUserModel, UserModel } from './user.model';
 import { IUserService, UserService } from './user.service';
-import { UserController } from './user.controller';
+import { Router } from 'express';
 
 const router = Router();
 

--- a/packages/api/src/user/user.service.ts
+++ b/packages/api/src/user/user.service.ts
@@ -1,13 +1,13 @@
-import { IUserModel } from './user.model';
+import { ENV } from '../config/env_variables';
 import { ConflictError, NotFoundError } from '../utils/errors.utils';
 import { generateUUID } from '../utils/uuid.utils';
-import bcrypt from 'bcryptjs';
-import { ENV } from '../config/env_variables';
+import { IUserModel } from './user.model';
 import {
   User,
   UserResponsePublic,
   AuthenticationRegisterRequestPublicSchema,
 } from '@dev-dashboard/shared';
+import bcrypt from 'bcryptjs';
 
 export interface IUserService {
   create(

--- a/packages/api/src/utils/jwt.utils.ts
+++ b/packages/api/src/utils/jwt.utils.ts
@@ -1,8 +1,8 @@
-import jwt, { SignOptions, VerifyOptions } from 'jsonwebtoken';
 import { ENV } from '../config/env_variables';
-import { Request } from 'express';
-import { AuthorizationTokenPayload } from '@dev-dashboard/shared';
 import { UnauthorizedError } from './errors.utils';
+import { AuthorizationTokenPayload } from '@dev-dashboard/shared';
+import { Request } from 'express';
+import jwt, { SignOptions, VerifyOptions } from 'jsonwebtoken';
 
 export const generateJWT = (payload: AuthorizationTokenPayload): string => {
   if (!ENV.JWT_SECRET) {

--- a/packages/api/src/utils/uuid.utils.ts
+++ b/packages/api/src/utils/uuid.utils.ts
@@ -1,5 +1,5 @@
-import { v4 as uuidv4 } from 'uuid';
 import crypto from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
 
 export const generateUUID = (): string => uuidv4();
 

--- a/packages/app/eslint.config.js
+++ b/packages/app/eslint.config.js
@@ -1,9 +1,9 @@
 import js from '@eslint/js';
-import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
-import tseslint from 'typescript-eslint';
 import { globalIgnores } from 'eslint/config';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config([
   globalIgnores(['dist']),

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,7 +1,7 @@
-import { Routes, Route, Navigate } from 'react-router';
+import AppLayout from './components/layout/AppLayout';
 import { PublicRoute, ProtectedRoute } from './components/routes/Routes';
 import { LoginPage, TodosPage, RegisterPage, SettingsPage } from './pages';
-import AppLayout from './components/layout/AppLayout';
+import { Routes, Route, Navigate } from 'react-router';
 
 function App() {
   return (

--- a/packages/app/src/components/layout/AppLayout.tsx
+++ b/packages/app/src/components/layout/AppLayout.tsx
@@ -1,5 +1,5 @@
-import { Outlet } from 'react-router';
 import Sidebar from './Sidebar';
+import { Outlet } from 'react-router';
 
 const AppLayout = () => {
   return (

--- a/packages/app/src/components/layout/Sidebar.tsx
+++ b/packages/app/src/components/layout/Sidebar.tsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router';
 
 export default function Sidebar() {
   return (
-    <aside className="w-64 flex flex-col border-r bg-[var(--color-surface)]">
-      <div className="p-8 border-b">
+    <aside className="flex w-64 flex-col border-r bg-[var(--color-surface)]">
+      <div className="border-b p-8">
         <div className="text-lg font-normal">Hello, User!</div>
       </div>
 
@@ -13,27 +13,27 @@ export default function Sidebar() {
           <li>
             <Link
               to="/todos"
-              className="flex items-center gap-2 px-4 py-2 border rounded-xl hover:border hover:shadow-sm"
+              className="flex items-center gap-2 rounded-xl border px-4 py-2 hover:border hover:shadow-sm"
             >
-              <DocumentTextIcon className="w-5 h-5" />
+              <DocumentTextIcon className="h-5 w-5" />
               Todos
             </Link>
           </li>
         </ul>
       </nav>
 
-      <div className="p-4 border-t">
+      <div className="border-t p-4">
         <Link
           to="/settings"
-          className="flex items-center gap-2 p-2 border shadow-sm rounded-xl"
+          className="flex items-center gap-2 rounded-xl border p-2 shadow-sm"
         >
-          <div className="w-8 h-8 rounded-full"></div>
+          <div className="h-8 w-8 rounded-full"></div>
           <div>
             <div className="text-sm font-normal">
               Angelo Ian Michael Cardona
             </div>
-            <div className="text-xs flex items-center">
-              <Cog6ToothIcon className="w-4 h-4 mr-1" />
+            <div className="flex items-center text-xs">
+              <Cog6ToothIcon className="mr-1 h-4 w-4" />
               Settings
             </div>
           </div>

--- a/packages/app/src/components/routes/Routes.tsx
+++ b/packages/app/src/components/routes/Routes.tsx
@@ -1,6 +1,6 @@
-import { Navigate, Outlet } from 'react-router';
 import { useAuth } from '../../hooks/useAuth';
 import LoadingSpinner from '../shared/LoadingSpinner';
+import { Navigate, Outlet } from 'react-router';
 
 export const ProtectedRoute = () => {
   const { state } = useAuth();

--- a/packages/app/src/components/shared/LoadingSpinner.tsx
+++ b/packages/app/src/components/shared/LoadingSpinner.tsx
@@ -1,6 +1,6 @@
 const LoadingSpinner = () => (
-  <div className="flex items-center justify-center min-h-screen">
-    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+  <div className="flex min-h-screen items-center justify-center">
+    <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
     <span className="ml-2">Loading...</span>
   </div>
 );

--- a/packages/app/src/context/AuthContext.tsx
+++ b/packages/app/src/context/AuthContext.tsx
@@ -1,3 +1,8 @@
+import type { UserResponsePublic } from '../../../shared/src/types/user.type';
+import LoadingSpinner from '../components/shared/LoadingSpinner';
+import { authApi } from '../lib/auth';
+import { userApi } from '../lib/user';
+import { isAxiosError } from 'axios';
 import {
   createContext,
   useEffect,
@@ -6,11 +11,6 @@ import {
   type Dispatch,
   type ReactNode,
 } from 'react';
-import { authApi } from '../lib/auth';
-import { isAxiosError } from 'axios';
-import type { UserResponsePublic } from '../../../shared/src/types/user.type';
-import LoadingSpinner from '../components/shared/LoadingSpinner';
-import { userApi } from '../lib/user';
 
 type State = {
   authUser: UserResponsePublic | null;

--- a/packages/app/src/features/login/components/LoginForm/index.tsx
+++ b/packages/app/src/features/login/components/LoginForm/index.tsx
@@ -18,7 +18,7 @@ const LoginForm = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4 w-80">
+    <form onSubmit={handleSubmit} className="flex w-80 flex-col gap-4">
       <input
         type="email"
         value={email}

--- a/packages/app/src/features/login/hooks/useLoginMutation.ts
+++ b/packages/app/src/features/login/hooks/useLoginMutation.ts
@@ -1,9 +1,9 @@
-import { useNavigate } from 'react-router';
-import { useAuth } from '../../../hooks/useAuth';
-import { useMutation } from '@tanstack/react-query';
-import { loginApi } from '../api/loginApi';
 import { AUTH_REDUCER_ACTION_TYPE } from '../../../context/AuthContext';
+import { useAuth } from '../../../hooks/useAuth';
+import { loginApi } from '../api/loginApi';
 import type { AuthenticationLoginRequestPublicSchema } from '@dev-dashboard/shared';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 
 export const useLoginMutation = () => {
   const navigate = useNavigate();

--- a/packages/app/src/features/register/api/registerApi.ts
+++ b/packages/app/src/features/register/api/registerApi.ts
@@ -1,8 +1,8 @@
+import { publicClient } from '../../../lib/api';
 import type {
   AuthenticationRegisterRequestPublicSchema,
   AuthenticationResponsePublicSchema,
 } from '@dev-dashboard/shared';
-import { publicClient } from '../../../lib/api';
 
 export const registerApi = async (
   data: AuthenticationRegisterRequestPublicSchema

--- a/packages/app/src/features/register/hooks/useRegisterMutation.ts
+++ b/packages/app/src/features/register/hooks/useRegisterMutation.ts
@@ -1,9 +1,9 @@
-import { useMutation } from '@tanstack/react-query';
-import { registerApi } from '../api/registerApi';
-import { useNavigate } from 'react-router';
-import { useAuth } from '../../../hooks/useAuth';
 import { AUTH_REDUCER_ACTION_TYPE } from '../../../context/AuthContext';
+import { useAuth } from '../../../hooks/useAuth';
+import { registerApi } from '../api/registerApi';
 import type { AuthenticationRegisterRequestPublicSchema } from '@dev-dashboard/shared';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 
 export const useRegisterMutation = () => {
   const navigate = useNavigate();

--- a/packages/app/src/features/settings/api/apiKeysApi.ts
+++ b/packages/app/src/features/settings/api/apiKeysApi.ts
@@ -1,5 +1,5 @@
-import type { ApiKeyPublic } from '@dev-dashboard/shared';
 import { protectedClient } from '../../../lib/api';
+import type { ApiKeyPublic } from '@dev-dashboard/shared';
 
 const createKey = async (): Promise<ApiKeyPublic> => {
   const response = await protectedClient.post<ApiKeyPublic>('/api-keys/create');

--- a/packages/app/src/features/settings/components/api-keys/NewApiKeyModal.tsx
+++ b/packages/app/src/features/settings/components/api-keys/NewApiKeyModal.tsx
@@ -11,18 +11,18 @@ const NewApiKeyModal = ({ isOpen, onClose }: NewApiKeyModalProps) => {
       style={{}}
     >
       <div
-        className="bg-[var(--color-bg)] text-[var(--color-fg)] p-8 rounded-lg border border-[var(--color-border)] min-w-[300px] relative shadow-lg"
+        className="relative min-w-[300px] rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-8 text-[var(--color-fg)] shadow-lg"
         role="dialog"
         aria-modal="true"
       >
         <button
           onClick={onClose}
-          className="absolute top-2 right-2 text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] p-2 rounded transition"
+          className="absolute top-2 right-2 rounded p-2 text-[var(--color-fg-muted)] transition hover:text-[var(--color-fg)]"
           aria-label="Close"
         >
           &times;
         </button>
-        <h2 className="text-lg font-semibold mb-4">New API Key</h2>
+        <h2 className="mb-4 text-lg font-semibold">New API Key</h2>
         <div>Form goes here</div>
       </div>
     </div>

--- a/packages/app/src/features/settings/components/api-keys/SettingsApiKeys.tsx
+++ b/packages/app/src/features/settings/components/api-keys/SettingsApiKeys.tsx
@@ -1,9 +1,9 @@
+import { useMutateCreateKey } from '../../hooks/useMutateCreateKey';
+import { useQueryFetchKeys } from '../../hooks/useQueryFetchKeys';
+import NewApiKeyModal from './NewApiKeyModal';
 import ApiKeysItem from './SettingsApiKeysItem';
 import { PlusIcon } from '@heroicons/react/24/outline';
 import { useState } from 'react';
-import { useQueryFetchKeys } from '../../hooks/useQueryFetchKeys';
-import { useMutateCreateKey } from '../../hooks/useMutateCreateKey';
-import NewApiKeyModal from './NewApiKeyModal';
 
 const SettingsApiKeys = () => {
   const { data: keys, isLoading } = useQueryFetchKeys();
@@ -20,27 +20,27 @@ const SettingsApiKeys = () => {
 
   return (
     <>
-      <section className="p-8 border rounded-2xl border-[var(--color-border)]">
-        <div className="flex items-center justify-between mb-4">
+      <section className="rounded-2xl border border-[var(--color-border)] p-8">
+        <div className="mb-4 flex items-center justify-between">
           <h2 className="text-xl font-normal">API Keys</h2>
           <button
             type="button"
-            className="inline-flex items-center justify-center px-3 py-1 border border-[var(--color-border)] rounded-md text-sm font-normal hover:bg-[var(--color-border)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="inline-flex items-center justify-center rounded-md border border-[var(--color-border)] px-3 py-1 text-sm font-normal transition-colors hover:bg-[var(--color-border)] disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Create a new API Key"
             onClick={handleCreateKey}
             disabled={createKey.isPending}
           >
-            <PlusIcon className="h-5 w-5 mr-1" />
+            <PlusIcon className="mr-1 h-5 w-5" />
             {createKey.isPending ? 'Creating...' : 'New Key'}
           </button>
         </div>
-        <p className="text-sm mb-4 max-w-2xl">
+        <p className="mb-4 max-w-2xl text-sm">
           These keys allow your VSCode extension to connect securely to your
           account. Treat them like passwords and do not share them.
         </p>
-        <div className="border border-[var(--color-border)] rounded-lg py-2 min-h-[160px] overflow-auto">
+        <div className="min-h-[160px] overflow-auto rounded-lg border border-[var(--color-border)] py-2">
           {isLoading ? (
-            <div className="flex items-center justify-center h-full text-sm">
+            <div className="flex h-full items-center justify-center text-sm">
               Loading keys...
             </div>
           ) : keys && keys.length > 0 ? (
@@ -54,7 +54,7 @@ const SettingsApiKeys = () => {
               ))}
             </ul>
           ) : (
-            <div className="flex items-center justify-center h-full text-sm">
+            <div className="flex h-full items-center justify-center text-sm">
               No API keys have been created yet.
             </div>
           )}

--- a/packages/app/src/features/settings/components/api-keys/SettingsApiKeysItem.tsx
+++ b/packages/app/src/features/settings/components/api-keys/SettingsApiKeysItem.tsx
@@ -8,7 +8,7 @@ const SettingsApiKeysItem = ({
   createdAt,
 }: SettingsApiKeysItemProps) => {
   return (
-    <li className="flex items-center justify-between px-4 py-3 border-b border-[var(--color-border)]">
+    <li className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3">
       <div className="flex flex-col">
         <span className="font-sans text-base text-[var(--color-fg)]">
           {description || 'Untitled Key'}
@@ -19,7 +19,7 @@ const SettingsApiKeysItem = ({
       </div>
       <button
         type="button"
-        className="ml-4 text-sm border border-[var(--color-border)] px-2 py-1 rounded font-normal text-[var(--color-fg)]"
+        className="ml-4 rounded border border-[var(--color-border)] px-2 py-1 text-sm font-normal text-[var(--color-fg)]"
       >
         Edit
       </button>

--- a/packages/app/src/features/settings/hooks/useMutateCreateKey.ts
+++ b/packages/app/src/features/settings/hooks/useMutateCreateKey.ts
@@ -1,5 +1,5 @@
-import { useMutation } from '@tanstack/react-query';
 import { createKey } from '../api/apiKeysApi';
+import { useMutation } from '@tanstack/react-query';
 
 export const useMutateCreateKey = () => {
   return useMutation({

--- a/packages/app/src/features/settings/hooks/useQueryFetchKeys.ts
+++ b/packages/app/src/features/settings/hooks/useQueryFetchKeys.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { fetchKeys } from '../api/apiKeysApi';
+import { useQuery } from '@tanstack/react-query';
 
 export const useQueryFetchKeys = () => {
   return useQuery({

--- a/packages/app/src/features/todos/api/todosApi.ts
+++ b/packages/app/src/features/todos/api/todosApi.ts
@@ -1,10 +1,10 @@
+import { protectedClient } from '../../../lib/api';
 import type {
   CreateResolution,
   ProjectNames,
   TodoResolution,
   TodosInfo,
 } from '@dev-dashboard/shared';
-import { protectedClient } from '../../../lib/api';
 
 const getLatest = async (): Promise<TodosInfo> => {
   const response = await protectedClient.get('/todos/batches/latest');

--- a/packages/app/src/features/todos/components/PendingResolutions.tsx
+++ b/packages/app/src/features/todos/components/PendingResolutions.tsx
@@ -1,23 +1,157 @@
-import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+import useMutateResolveTodos from '../hooks/useMutateResolveTodos';
+import useQueryPendingResolutions from '../hooks/useQueryPendingResolutions';
 import ResolutionsTable from './resolutions/ResolutionsTable';
-import { useState } from 'react';
+import { type CreateResolution } from '@dev-dashboard/shared';
+import {
+  ChevronDownIcon,
+  ChevronUpDownIcon,
+  ChevronUpIcon,
+  InformationCircleIcon,
+  PencilSquareIcon,
+  XMarkIcon,
+  CheckIcon,
+} from '@heroicons/react/24/outline';
+import { useMemo, useState, type JSX } from 'react';
+
+type TypeFilter = '' | 'bug' | 'feature' | 'chore' | string;
+type SortField = 'type' | 'content' | 'createdAt' | null;
+type SortDirection = 'asc' | 'desc';
+type SelectedReasons = Record<string, string>;
 
 const PendingResolutions = () => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
-  const [isToolbarOpen, setIsToolbarOpen] = useState<boolean>(false);
+  const [isTooltipVisible, setIsTooltipVisible] = useState<boolean>(false);
+
+  const { mutate } = useMutateResolveTodos();
+
+  const {
+    data: resolutions,
+    isLoading,
+    isError,
+  } = useQueryPendingResolutions();
+
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('');
+  const [sortField, setSortField] = useState<SortField>(null);
+  const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+
+  const [selectedReasons, setSelectedReasons] = useState<SelectedReasons>({});
+
+  const handleReasonChange = (id: string, value: string): void => {
+    setSelectedReasons((prev: SelectedReasons) => ({
+      ...prev,
+      [id]: value,
+    }));
+  };
+
+  const uniqueTypes = useMemo(
+    () => [...new Set(resolutions?.map(resolution => resolution.type) || [])],
+    [resolutions]
+  );
+
+  const handleSort = (field: string): void => {
+    if (field === 'type' || field === 'content' || field === 'createdAt') {
+      if (sortField === field) {
+        setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+      } else {
+        setSortField(field);
+        setSortDirection('asc');
+      }
+    }
+  };
+
+  const getSortIcon = (key: string): JSX.Element | null => {
+    if (key !== 'type' && key !== 'content' && key !== 'createdAt') {
+      return null;
+    }
+    const field = key as 'type' | 'content' | 'createdAt';
+    if (sortField !== field) {
+      return (
+        <ChevronUpDownIcon
+          className="inline-block h-4 w-4"
+          aria-hidden="true"
+        />
+      );
+    }
+    return sortDirection === 'asc' ? (
+      <ChevronUpIcon className="inline-block h-4 w-4" aria-hidden="true" />
+    ) : (
+      <ChevronDownIcon className="inline-block h-4 w-4" aria-hidden="true" />
+    );
+  };
+
+  const filteredAndSortedResolutions = useMemo(() => {
+    if (!resolutions) return [];
+
+    let filtered = resolutions.filter(resolution => {
+      const matchesType = !typeFilter || resolution.type === typeFilter;
+      return matchesType;
+    });
+
+    if (sortField) {
+      filtered = [...filtered].sort((a, b) => {
+        let aValue, bValue;
+
+        switch (sortField) {
+          case 'type':
+            aValue = a.type;
+            bValue = b.type;
+            break;
+          case 'content':
+            aValue = a.content.toLowerCase();
+            bValue = b.content.toLowerCase();
+            break;
+          case 'createdAt':
+            aValue = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+            bValue = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+            break;
+          default:
+            return 0;
+        }
+
+        if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
+        if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
+        return 0;
+      });
+    }
+
+    return filtered;
+  }, [resolutions, typeFilter, sortField, sortDirection]);
+
+  const handleSubmit = (): void => {
+    if (!resolutions) return;
+    const payload: Array<{
+      id: string;
+      syncId: string;
+      reason: CreateResolution['reason'];
+    }> = resolutions
+      .filter(resolution => selectedReasons[resolution.id])
+      .map(resolution => ({
+        id: resolution.id,
+        syncId: resolution.syncId,
+        reason: selectedReasons[resolution.id] as CreateResolution['reason'],
+      }));
+    mutate(payload);
+  };
+
+  const hasValidSelection = useMemo(() => {
+    if (!resolutions) return false;
+    return resolutions.some(resolution => !!selectedReasons[resolution.id]);
+  }, [resolutions, selectedReasons]);
+
   return (
-    <section className="rounded-4xl border pt-8 h-full flex flex-col bg-[var(--color-surface)]">
-      <div className="flex items-center justify-between mb-8 px-8">
+    <section className="relative flex h-full flex-col rounded-4xl border bg-[var(--color-surface)] pt-8">
+      <div className="mb-8 flex items-center justify-between px-8">
         <h2 className="flex items-center text-3xl">
           Pending Resolutions
           <div className="relative ml-3">
-            <QuestionMarkCircleIcon
-              className="w-6 h-6 cursor-pointer"
-              onClick={() => setIsToolbarOpen(!isToolbarOpen)}
+            <InformationCircleIcon
+              className="h-6 w-6 cursor-pointer"
+              onMouseEnter={() => setIsTooltipVisible(true)}
+              onMouseLeave={() => setIsTooltipVisible(false)}
             />
-            {isToolbarOpen && (
-              <div className="absolute top-full mt-2 left-1/2 -translate-x-1/2 w-72 p-4 bg-[var(--color-surface)] border rounded-4xl shadow-lg z-10">
-                <p className="text-sm font-normal text-left">
+            {isTooltipVisible && (
+              <div className="absolute top-full left-1/2 z-10 mt-2 w-72 -translate-x-1/2 rounded-2xl border bg-[var(--color-surface)] p-4 shadow-lg">
+                <p className="text-left text-sm font-normal">
                   Pending resolutions are TODOs that need your input. Use Edit
                   mode to assign reasons or resolve them.
                 </p>
@@ -27,16 +161,47 @@ const PendingResolutions = () => {
         </h2>
         <button
           onClick={() => setIsEditMode(!isEditMode)}
-          className="border rounded-4xl px-4 py-2 text-sm hover:bg-[var(--color-primary)]"
+          className="flex items-center gap-2 rounded-4xl border px-6 text-base font-medium shadow-md hover:bg-[var(--color-fg)]/[0.03]"
         >
-          {isEditMode ? 'Submit' : 'Edit'}
+          {isEditMode ? (
+            <XMarkIcon className="h-5 w-5" />
+          ) : (
+            <PencilSquareIcon className="h-5 w-5" />
+          )}
+          {isEditMode ? 'Cancel' : 'Edit'}
         </button>
       </div>
       <div className="flex-1 overflow-hidden rounded-b-4xl">
-        <div className="overflow-y-auto h-full">
-          <ResolutionsTable isEditMode={isEditMode} />
+        <div className="h-full overflow-y-auto">
+          <ResolutionsTable
+            isEditMode={isEditMode}
+            resolutions={filteredAndSortedResolutions}
+            isLoading={isLoading}
+            isError={isError}
+            getSortIcon={getSortIcon}
+            handleSort={handleSort}
+            setTypeFilter={setTypeFilter}
+            typeFilter={typeFilter}
+            uniqueTypes={uniqueTypes}
+            selectedReasons={selectedReasons}
+            onReasonChange={handleReasonChange}
+          />
         </div>
       </div>
+      {isEditMode && resolutions && resolutions.length > 0 && (
+        <div className="absolute bottom-6 left-1/2 -translate-x-1/2">
+          <button
+            onClick={handleSubmit}
+            disabled={!hasValidSelection}
+            className={`flex items-center gap-2 rounded-4xl border bg-[var(--color-surface)] px-6 py-2 text-base font-medium shadow-md ${
+              !hasValidSelection ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+            }`}
+          >
+            <CheckIcon className="h-6 w-6" />
+            Submit
+          </button>
+        </div>
+      )}
     </section>
   );
 };

--- a/packages/app/src/features/todos/components/TodosHistory.tsx
+++ b/packages/app/src/features/todos/components/TodosHistory.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react';
-import { TableCellsIcon } from '@heroicons/react/24/outline';
-import TodosHistoryTable from './history/TodosHistoryTable.tsx';
-import TodosHistoryProjectMenu from './history/TodosHistoryProjectMenu.tsx';
 import useQueryProjectNames from '../hooks/useQueryProjectNames.ts';
 import useQueryProjectTodos from '../hooks/useQueryProjectTodos.ts';
+import TodosHistoryProjectMenu from './history/TodosHistoryProjectMenu.tsx';
+import TodosHistoryTable from './history/TodosHistoryTable.tsx';
+import { useState } from 'react';
 
 const TodosHistory = () => {
   const [selectedProjectIndex, setSelectedProjectIndex] = useState<number>(0);
@@ -58,8 +57,8 @@ const TodosHistory = () => {
   };
 
   return (
-    <div className="rounded-4xl border pt-8 flex flex-col bg-[var(--color-surface)] h-full">
-      <div className="flex items-center justify-between mb-8 px-8">
+    <div className="flex h-full flex-col rounded-4xl border bg-[var(--color-surface)] pt-8">
+      <div className="mb-8 flex items-center justify-between px-8">
         <h2 className="flex items-center text-3xl">History</h2>
         <TodosHistoryProjectMenu
           title={displayTitle}
@@ -69,7 +68,7 @@ const TodosHistory = () => {
           canGoRight={selectedProjectIndex < projects.length - 1}
         />
       </div>
-      <div className="flex-1 min-h-0 overflow-auto rounded-b-4xl">
+      <div className="min-h-0 flex-1 overflow-auto rounded-b-4xl">
         {renderContent()}
       </div>
     </div>

--- a/packages/app/src/features/todos/components/history/TodosHistoryProjectMenu.tsx
+++ b/packages/app/src/features/todos/components/history/TodosHistoryProjectMenu.tsx
@@ -20,18 +20,18 @@ const TodosHistoryProjectMenu = ({
       <button
         onClick={onGoLeft}
         disabled={!canGoLeft}
-        className="flex h-8 w-8 items-center justify-center rounded-4xl border disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[var(--color-surface)]"
+        className="flex h-8 w-8 items-center justify-center rounded-4xl border hover:bg-[var(--color-surface)] disabled:cursor-not-allowed disabled:opacity-50"
         aria-label="Previous Project"
       >
         <ChevronLeftIcon className="h-4 w-4" />
       </button>
-      <span className="min-w-[160px] select-none text-center text-base uppercase">
+      <span className="min-w-[160px] text-center text-base uppercase select-none">
         {title}
       </span>
       <button
         onClick={onGoRight}
         disabled={!canGoRight}
-        className="flex h-8 w-8 items-center justify-center rounded-4xl border disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[var(--color-surface)]"
+        className="flex h-8 w-8 items-center justify-center rounded-4xl border hover:bg-[var(--color-surface)] disabled:cursor-not-allowed disabled:opacity-50"
         aria-label="Next Project"
       >
         <ChevronRightIcon className="h-4 w-4" />

--- a/packages/app/src/features/todos/components/history/TodosHistoryTable.tsx
+++ b/packages/app/src/features/todos/components/history/TodosHistoryTable.tsx
@@ -1,12 +1,12 @@
+import TodosHistoryTableHeader from './TodosHistoryTableHeader';
+import TodosHistoryTableRow from './TodosHistoryTableRow';
 import type { FlattenedTodo, TodoBatch } from '@dev-dashboard/shared';
-import { useMemo, useState } from 'react';
 import {
   ChevronUpDownIcon,
   ChevronUpIcon,
   ChevronDownIcon,
 } from '@heroicons/react/24/outline';
-import TodosHistoryTableHeader from './TodosHistoryTableHeader';
-import TodosHistoryTableRow from './TodosHistoryTableRow';
+import { useMemo, useState } from 'react';
 
 interface TodosHistoryTableProps {
   batch: TodoBatch[];
@@ -66,15 +66,15 @@ const TodosHistoryTable = ({ batch }: TodosHistoryTableProps) => {
     if (sortField !== field) {
       return (
         <ChevronUpDownIcon
-          className="inline-block w-4 h-4"
+          className="inline-block h-4 w-4"
           aria-hidden="true"
         />
       );
     }
     return sortDirection === 'asc' ? (
-      <ChevronUpIcon className="inline-block w-4 h-4" aria-hidden="true" />
+      <ChevronUpIcon className="inline-block h-4 w-4" aria-hidden="true" />
     ) : (
-      <ChevronDownIcon className="inline-block w-4 h-4" aria-hidden="true" />
+      <ChevronDownIcon className="inline-block h-4 w-4" aria-hidden="true" />
     );
   };
 
@@ -115,8 +115,8 @@ const TodosHistoryTable = ({ batch }: TodosHistoryTableProps) => {
   }, [flattenedTodos, typeFilter, sortField, sortDirection]);
 
   return (
-    <div className="h-full flex flex-col min-h-0">
-      <div className="flex-1 overflow-auto min-h-0">
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1 overflow-auto">
         <table className="w-full table-auto">
           <TodosHistoryTableHeader
             getSortIcon={getSortIcon}

--- a/packages/app/src/features/todos/components/history/TodosHistoryTableHeader.tsx
+++ b/packages/app/src/features/todos/components/history/TodosHistoryTableHeader.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode, useState } from 'react';
 import IconSelector from '../common/IconSelector';
+import { type ReactNode, useState } from 'react';
 
 interface TodosHistoryTableHeaderProps {
   typeFilter: string;
@@ -20,13 +20,17 @@ const TodosHistoryTableHeader = ({
 }: TodosHistoryTableHeaderProps) => {
   const [showTypeDropdown, setShowTypeDropdown] = useState(false);
   return (
-    <thead className="sticky top-0 bg-[var(--color-surface)] z-2">
+    <thead className="sticky top-0 z-2 bg-[var(--color-surface)]">
       <tr className="border-b">
-        <th className="w-36 whitespace-nowrap px-6 py-2 text-left text-base">
+        <th
+          className="w-36 px-6 py-3 text-left text-base whitespace-nowrap"
+          onMouseEnter={() => setShowTypeDropdown(true)}
+          onMouseLeave={() => setShowTypeDropdown(false)}
+        >
           <div className="relative">
             <button
               onClick={() => handleSort('type')}
-              className="flex cursor-pointer select-none items-center gap-2"
+              className="flex cursor-pointer items-center gap-2 select-none"
               title="Sort by Type"
               type="button"
             >
@@ -42,7 +46,7 @@ const TodosHistoryTableHeader = ({
               {getSortIcon('type')}
             </button>
             {showTypeDropdown && (
-              <div className="absolute z-10 mt-2 w-40 rounded-lg border bg-[var(--color-surface)] shadow-md">
+              <div className="absolute z-10 mt-2 w-40 rounded-2xl border bg-[var(--color-surface)] shadow-md">
                 <div
                   className="cursor-pointer rounded-md px-6 py-2 text-base uppercase hover:bg-[var(--color-fg)]/5"
                   onClick={() => {
@@ -76,10 +80,10 @@ const TodosHistoryTableHeader = ({
             )}
           </div>
         </th>
-        <th className="whitespace-nowrap px-6 py-3 text-left text-base">
+        <th className="px-6 py-3 text-left text-base whitespace-nowrap">
           <button
             onClick={() => handleSort('content')}
-            className="flex cursor-pointer select-none items-center gap-2"
+            className="flex cursor-pointer items-center gap-2 select-none"
             title="Sort by Content"
             type="button"
           >
@@ -88,10 +92,10 @@ const TodosHistoryTableHeader = ({
           </button>
         </th>
         {showDateFilter && (
-          <th className="w-56 whitespace-nowrap px-6 py-3 text-left text-base">
+          <th className="w-56 px-6 py-3 text-left text-base whitespace-nowrap">
             <button
               onClick={() => handleSort('date')}
-              className="flex cursor-pointer select-none items-center gap-2"
+              className="flex cursor-pointer items-center gap-2 select-none"
               title="Sort by Date"
               type="button"
             >

--- a/packages/app/src/features/todos/components/history/TodosHistoryTableRow.tsx
+++ b/packages/app/src/features/todos/components/history/TodosHistoryTableRow.tsx
@@ -1,5 +1,5 @@
-import type { FlattenedTodo } from '@dev-dashboard/shared';
 import IconSelector from '../common/IconSelector';
+import type { FlattenedTodo } from '@dev-dashboard/shared';
 
 interface TodosHistoryTableRowProps {
   todo: FlattenedTodo;
@@ -11,14 +11,14 @@ const TodosHistoryTableRow = ({
   showDateFilter,
 }: TodosHistoryTableRowProps) => {
   return (
-    <tr className="border-b border-[var(--color-fg)]/10 hover:bg-[var(--color-fg)]/[0.03] hover:border-b-2 hover:border-[var(--color-primary)]">
+    <tr className="border-b border-[var(--color-fg)]/10 hover:border-b-2 hover:border-[var(--color-primary)] hover:bg-[var(--color-fg)]/[0.03]">
       <td className="px-6 py-3 align-middle text-base normal-case">
         <div className="flex items-center gap-2">
           <IconSelector type={todo.type} />
           <span>{todo.type}</span>
         </div>
       </td>
-      <td className="max-w-xs px-6 py-2 align-middle font-bold text-base normal-case">
+      <td className="max-w-xs px-6 py-2 align-middle text-base font-bold normal-case">
         {todo.content}
       </td>
       {showDateFilter && (

--- a/packages/app/src/features/todos/components/resolutions/ResolutionsTableHeader.tsx
+++ b/packages/app/src/features/todos/components/resolutions/ResolutionsTableHeader.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import IconSelector from '../common/IconSelector';
+import { useState } from 'react';
 
 interface ResolutionsTableHeaderProps {
   typeFilter: string;
@@ -20,29 +20,28 @@ const ResolutionsTableHeader = ({
 }: ResolutionsTableHeaderProps) => {
   const [showTypeDropdown, setShowTypeDropdown] = useState(false);
   return (
-    <thead className="sticky top-0 bg-[var(--color-surface)] z-2 border-b">
+    <thead className="sticky top-0 z-2 border-b bg-[var(--color-surface)]">
       <tr className="border-b">
-        <th className="w-36 whitespace-nowrap px-6 py-2 text-left text-base">
+        <th
+          className="w-36 px-6 py-2 text-left text-base whitespace-nowrap"
+          onMouseEnter={() => setShowTypeDropdown(true)}
+          onMouseLeave={() => setShowTypeDropdown(false)}
+        >
           <div className="relative">
             <button
               onClick={() => handleSort('type')}
-              className="flex cursor-pointer select-none items-center gap-2"
+              className="flex cursor-pointer items-center gap-2 select-none"
               title="Sort by Type"
               type="button"
             >
-              <span
-                onClick={e => {
-                  e.stopPropagation();
-                  setShowTypeDropdown(!showTypeDropdown);
-                }}
-                title="Filter by Type"
-              >
+              <span title="Filter by Type">
                 {typeFilter === '' ? 'Type' : typeFilter}
               </span>
               {getSortIcon('type')}
             </button>
+
             {showTypeDropdown && (
-              <div className="absolute z-10 mt-2 w-40 rounded-lg border bg-[var(--color-surface)] shadow-md">
+              <div className="absolute z-10 mt-1 w-40 rounded-2xl border bg-[var(--color-surface)] shadow-md">
                 <div
                   className="cursor-pointer rounded-md px-6 py-2 text-base uppercase hover:bg-[var(--color-fg)]/5"
                   onClick={() => {
@@ -76,10 +75,10 @@ const ResolutionsTableHeader = ({
             )}
           </div>
         </th>
-        <th className="whitespace-nowrap px-6 py-3 text-left text-base">
+        <th className="px-6 py-3 text-left text-base whitespace-nowrap">
           <button
             onClick={() => handleSort('content')}
-            className="flex cursor-pointer select-none items-center gap-2"
+            className="flex cursor-pointer items-center gap-2 select-none"
             title="Sort by Content"
             type="button"
           >
@@ -88,10 +87,10 @@ const ResolutionsTableHeader = ({
           </button>
         </th>
 
-        <th className="w-56 whitespace-nowrap px-6 py-3 text-left text-base">
+        <th className="w-56 px-6 py-3 text-left text-base whitespace-nowrap">
           <button
             onClick={() => handleSort('createdAt')}
-            className="flex cursor-pointer select-none items-center gap-2"
+            className="flex cursor-pointer items-center gap-2 select-none"
             title="Sort by Created At"
             type="button"
           >
@@ -100,8 +99,8 @@ const ResolutionsTableHeader = ({
           </button>
         </th>
         {isEditMode && (
-          <th className="w-64 whitespace-nowrap px-6 py-2 text-left text-base">
-            Resolution
+          <th className="w-72 px-6 py-3 text-left text-base whitespace-nowrap">
+            Reason
           </th>
         )}
       </tr>

--- a/packages/app/src/features/todos/components/resolutions/ResolutionsTableRow.tsx
+++ b/packages/app/src/features/todos/components/resolutions/ResolutionsTableRow.tsx
@@ -1,6 +1,6 @@
+import IconSelector from '../common/IconSelector';
 import type { TodoResolution } from '@dev-dashboard/shared';
 import { TodoReasonEnum } from '@dev-dashboard/shared';
-import IconSelector from '../common/IconSelector';
 
 interface ResolutionsTableRowProps {
   resolution: TodoResolution;
@@ -16,27 +16,27 @@ const ResolutionsTableRow = ({
   onReasonChange,
 }: ResolutionsTableRowProps) => {
   return (
-    <tr className="border-b border-[var(--color-fg)]/10 hover:bg-[var(--color-fg)]/[0.03] hover:border-b-2 hover:border-[var(--color-primary)]">
+    <tr className="border-b border-[var(--color-fg)]/10 hover:border-b-2 hover:border-[var(--color-primary)] hover:bg-[var(--color-fg)]/[0.03]">
       <td className="px-6 py-3 align-middle text-base normal-case">
         <div className="flex items-center gap-2">
           <IconSelector type={resolution.type} />
           <span>{resolution.type}</span>
         </div>
       </td>
-      <td className="max-w-xs px-6 py-2 align-middle font-bold text-base normal-case ">
+      <td className="max-w-xs px-6 py-3 align-middle text-base font-bold normal-case">
         {resolution.content}
       </td>
-      <td className="px-6 py-2 align-middle text-base normal-case">
+      <td className="px-6 py-3 align-middle text-base normal-case">
         {resolution.createdAt
           ? new Date(resolution.createdAt).toLocaleString()
           : 'N/A'}
       </td>
       {isEditMode && (
-        <td className="px-6 py-2 align-middle text-base normal-case">
+        <td className="w-72 px-6 py-3 text-left align-middle text-base whitespace-nowrap normal-case">
           <select
             value={selectedReason}
             onChange={e => onReasonChange(e.target.value)}
-            className="w-full border border-[var(--color-fg)] rounded px-4 py-1 text-base truncate"
+            className="w-full truncate rounded border border-[var(--color-fg)] px-4 text-base"
           >
             <option value="">Select reason</option>
             {TodoReasonEnum.options.map((option: string) => (

--- a/packages/app/src/features/todos/hooks/useMutateResolveTodos.ts
+++ b/packages/app/src/features/todos/hooks/useMutateResolveTodos.ts
@@ -1,6 +1,6 @@
-import { useMutation } from '@tanstack/react-query';
-import type { CreateResolution, TodoResolution } from '@dev-dashboard/shared';
 import { postResolutions } from '../api/todosApi';
+import type { CreateResolution, TodoResolution } from '@dev-dashboard/shared';
+import { useMutation } from '@tanstack/react-query';
 
 const useMutateResolveTodos = () => {
   return useMutation<TodoResolution[], Error, CreateResolution[]>({

--- a/packages/app/src/features/todos/hooks/useQueryLatestTodos.ts
+++ b/packages/app/src/features/todos/hooks/useQueryLatestTodos.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { getLatest } from '../api/todosApi';
+import { useQuery } from '@tanstack/react-query';
 
 const useQueryLatestTodos = () => {
   return useQuery({

--- a/packages/app/src/features/todos/hooks/useQueryPendingResolutions.ts
+++ b/packages/app/src/features/todos/hooks/useQueryPendingResolutions.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { getPendingResolutions } from '../api/todosApi';
+import { useQuery } from '@tanstack/react-query';
 
 const useQueryPendingResolutions = () => {
   return useQuery({

--- a/packages/app/src/features/todos/hooks/useQueryProjectNames.ts
+++ b/packages/app/src/features/todos/hooks/useQueryProjectNames.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { getProjectNames } from '../api/todosApi';
+import { useQuery } from '@tanstack/react-query';
 
 const useQueryProjectNames = () => {
   return useQuery({

--- a/packages/app/src/features/todos/hooks/useQueryProjectTodos.ts
+++ b/packages/app/src/features/todos/hooks/useQueryProjectTodos.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { getByProject } from '../api/todosApi';
+import { useQuery } from '@tanstack/react-query';
 
 const useQueryProjectTodos = (projectName: string) => {
   return useQuery({

--- a/packages/app/src/hooks/useAuth.ts
+++ b/packages/app/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
-import { useContext } from 'react';
 import AuthContext from '../context/AuthContext';
+import { useContext } from 'react';
 
 export const useAuth = () => {
   const auth = useContext(AuthContext);

--- a/packages/app/src/lib/auth.ts
+++ b/packages/app/src/lib/auth.ts
@@ -1,5 +1,5 @@
-import type { AuthenticationResponsePublicSchema } from '@dev-dashboard/shared';
 import { publicClient } from './api';
+import type { AuthenticationResponsePublicSchema } from '@dev-dashboard/shared';
 
 export const authApi = {
   refresh: async (): Promise<AuthenticationResponsePublicSchema> => {

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter } from 'react-router';
+import App from './App.tsx';
 import { AuthContextProvider } from './context/AuthContext';
 import './index.css';
-import App from './App.tsx';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router';
 
 const queryClient = new QueryClient();
 

--- a/packages/app/src/pages/Login.tsx
+++ b/packages/app/src/pages/Login.tsx
@@ -2,7 +2,7 @@ import LoginForm from '../features/login/components/LoginForm';
 
 const LoginPage = () => {
   return (
-    <div className="flex flex-col items-center justify-center h-screen">
+    <div className="flex h-screen flex-col items-center justify-center">
       <h1>Login</h1>
       <LoginForm />
     </div>

--- a/packages/app/src/pages/Register.tsx
+++ b/packages/app/src/pages/Register.tsx
@@ -2,9 +2,9 @@ import RegisterForm from '../features/register/components/RegisterForm';
 
 const RegisterPage = () => {
   return (
-    <div className="flex items-center justify-center min-h-screen px-4">
-      <div className="w-full max-w-md rounded-lg shadow p-6">
-        <h1 className="font-inter text-4xl sm:text-5xl font-bold text-center mb-6">
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-md rounded-lg p-6 shadow">
+        <h1 className="font-inter mb-6 text-center text-4xl font-bold sm:text-5xl">
           Register
         </h1>
         <RegisterForm />

--- a/packages/app/src/pages/Settings.tsx
+++ b/packages/app/src/pages/Settings.tsx
@@ -1,10 +1,10 @@
-import { Cog6ToothIcon } from '@heroicons/react/24/outline';
 import SettingsApiKeys from '../features/settings/components/api-keys/SettingsApiKeys';
+import { Cog6ToothIcon } from '@heroicons/react/24/outline';
 
 const SettingsPage = () => {
   return (
-    <div className="h-screen flex flex-col p-8 overflow-hidden">
-      <header className="flex flex-shrink-0 items-center gap-3 mb-8">
+    <div className="flex h-screen flex-col overflow-hidden p-8">
+      <header className="mb-8 flex flex-shrink-0 items-center gap-3">
         <Cog6ToothIcon className="h-7 w-7" />
         <h1 className="text-4xl">Settings</h1>
       </header>

--- a/packages/app/src/pages/Todos.tsx
+++ b/packages/app/src/pages/Todos.tsx
@@ -1,23 +1,23 @@
-import { useState } from 'react';
-import { DocumentTextIcon } from '@heroicons/react/24/outline';
 import PendingResolutions from '../features/todos/components/PendingResolutions';
 import TodosHistory from '../features/todos/components/TodosHistory';
+import { DocumentTextIcon } from '@heroicons/react/24/outline';
+import { useState } from 'react';
 
 const TodosPage = () => {
   const [activeTab, setActiveTab] = useState('pending');
 
   return (
-    <div className="h-screen flex flex-col p-8 overflow-hidden bg-[var(--color-background)]">
-      <header className="flex flex-shrink-0 items-center gap-2 mb-4">
+    <div className="flex h-screen flex-col overflow-hidden bg-[var(--color-background)] p-8">
+      <header className="mb-4 flex flex-shrink-0 items-center gap-2">
         <DocumentTextIcon className="h-8 w-8" />
         <h1 className="text-4xl">Todos</h1>
       </header>
-      <div className="flex mb-4">
+      <div className="mb-4 flex">
         <button
           className={`px-4 py-2 text-lg font-medium transition-colors duration-200 ${
             activeTab === 'pending'
-              ? 'border-l-4 border-b-2 border-[var(--color-primary)] text-[var(--color-primary)]'
-              : 'border-l-4 border-b-2 border-transparent'
+              ? 'border-b-2 border-l-4 border-[var(--color-primary)] text-[var(--color-primary)]'
+              : 'border-b-2 border-l-4 border-transparent'
           }`}
           onClick={() => setActiveTab('pending')}
         >
@@ -26,8 +26,8 @@ const TodosPage = () => {
         <button
           className={`px-4 py-2 text-lg font-medium transition-colors duration-200 ${
             activeTab === 'history'
-              ? 'border-l-4 border-b-2 border-[var(--color-primary)] text-[var(--color-primary)]'
-              : 'border-l-4 border-b-2 border-transparent'
+              ? 'border-b-2 border-l-4 border-[var(--color-primary)] text-[var(--color-primary)]'
+              : 'border-b-2 border-l-4 border-transparent'
           }`}
           onClick={() => setActiveTab('history')}
         >
@@ -35,12 +35,12 @@ const TodosPage = () => {
         </button>
       </div>
       {activeTab === 'pending' && (
-        <div className="flex-1 min-h-0 overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-hidden">
           <PendingResolutions />
         </div>
       )}
       {activeTab === 'history' && (
-        <div className="flex-1 min-h-0 overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-hidden">
           <TodosHistory />
         </div>
       )}

--- a/packages/app/src/pages/index.ts
+++ b/packages/app/src/pages/index.ts
@@ -1,6 +1,6 @@
 import LoginPage from './Login';
 import RegisterPage from './Register';
-import TodosPage from './Todos';
 import SettingsPage from './Settings';
+import TodosPage from './Todos';
 
 export { LoginPage, RegisterPage, TodosPage, SettingsPage };

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],

--- a/packages/shared/src/schemas/auth.schema.ts
+++ b/packages/shared/src/schemas/auth.schema.ts
@@ -1,5 +1,5 @@
-import z from 'zod';
 import { userResponsePublicSchema } from './user.schema';
+import z from 'zod';
 
 // Helper Validation
 export const passwordStrengthValidation = (email?: string, username?: string) =>

--- a/packages/shared/src/schemas/todo.schema.ts
+++ b/packages/shared/src/schemas/todo.schema.ts
@@ -1,5 +1,5 @@
-import z from 'zod';
 import { VALIDATION_CONSTANTS } from '../constants/validations';
+import z from 'zod';
 
 export const TodoReasonEnum = z.enum([
   'done',

--- a/packages/shared/src/schemas/user.schema.ts
+++ b/packages/shared/src/schemas/user.schema.ts
@@ -1,5 +1,5 @@
-import z from 'zod';
 import { VALIDATION_CONSTANTS } from '../constants/validations';
+import z from 'zod';
 
 // Password Validation
 export const passwordSchema = z

--- a/packages/shared/src/types/api-key.type.ts
+++ b/packages/shared/src/types/api-key.type.ts
@@ -1,8 +1,8 @@
-import z from 'zod';
 import type {
   apiKeyPublicSchema,
   apiKeySchema,
 } from '../schemas/api-key.schema';
+import z from 'zod';
 
 export type ApiKey = z.infer<typeof apiKeySchema>;
 export type ApiKeyPublic = z.infer<typeof apiKeyPublicSchema>;

--- a/packages/shared/src/types/auth.type.ts
+++ b/packages/shared/src/types/auth.type.ts
@@ -1,5 +1,3 @@
-import z from 'zod';
-import { JwtPayload } from 'jsonwebtoken';
 import {
   authenticationLoginRequestPublicSchema,
   authenticationResponsePublicSchema,
@@ -9,6 +7,8 @@ import {
   authenticationSuccessResponsePrivateSchema,
   authorizationJwtSchema,
 } from '../schemas/auth.schema';
+import { JwtPayload } from 'jsonwebtoken';
+import z from 'zod';
 
 export type AuthenticationRegisterRequestPublicSchema = z.infer<
   typeof authenticationRegisterRequestPublicSchema

--- a/packages/shared/src/types/refresh-token.type.ts
+++ b/packages/shared/src/types/refresh-token.type.ts
@@ -1,8 +1,8 @@
-import z from 'zod';
 import {
   refreshTokenRecordAndPlainSchema,
   refreshTokenSchema,
 } from '../schemas/refresh-token.schema';
+import z from 'zod';
 
 export type RefreshToken = z.infer<typeof refreshTokenSchema>;
 export type RefreshTokenRecordAndPlain = z.infer<

--- a/packages/shared/src/types/todo.type.ts
+++ b/packages/shared/src/types/todo.type.ts
@@ -1,4 +1,3 @@
-import z from 'zod';
 import {
   todoMetaSchema,
   OtherTodoTypeEnum,
@@ -15,6 +14,7 @@ import {
   todoResolutionSchema,
   createResolutionSchema,
 } from '../schemas/todo.schema';
+import z from 'zod';
 
 export type TodoReasonEnumType = z.infer<typeof TodoReasonEnum>;
 export type PredefinedTodoTypeEnumType = z.infer<typeof PredefinedTodoTypeEnum>;

--- a/packages/shared/src/types/user.type.ts
+++ b/packages/shared/src/types/user.type.ts
@@ -1,5 +1,5 @@
-import z from 'zod';
 import { userSchema, userResponsePublicSchema } from '../schemas/user.schema';
+import z from 'zod';
 
 export type User = z.infer<typeof userSchema>;
 export type UserResponsePublic = z.infer<typeof userResponsePublicSchema>;

--- a/packages/vscode-extension/src/apis/todos-api.ts
+++ b/packages/vscode-extension/src/apis/todos-api.ts
@@ -1,5 +1,5 @@
-import { RawTodoBatch } from '@dev-dashboard/shared';
 import { protectedClient } from '../lib/api';
+import { RawTodoBatch } from '@dev-dashboard/shared';
 
 export const todosApi = {
   send: async (todos: RawTodoBatch) => {

--- a/packages/vscode-extension/src/commands/scanSetTodos.ts
+++ b/packages/vscode-extension/src/commands/scanSetTodos.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
 import { scanTodos } from '../services/scan-todos';
 import { TodosProvider } from '../webviews/todos/todos-provider';
+import * as vscode from 'vscode';
 
 export const scanSetTodosCommand = async (todosProvider: TodosProvider) => {
   try {

--- a/packages/vscode-extension/src/commands/sendTodos.ts
+++ b/packages/vscode-extension/src/commands/sendTodos.ts
@@ -1,7 +1,7 @@
-import * as vscode from 'vscode';
 import { postTodos } from '../services/post-todos';
-import { TodosProvider } from '../webviews/todos/todos-provider';
 import { batchTodos } from '../services/send/batch-todos';
+import { TodosProvider } from '../webviews/todos/todos-provider';
+import * as vscode from 'vscode';
 
 export const sendTodosCommand = async (todosProvider: TodosProvider) => {
   try {

--- a/packages/vscode-extension/src/commands/setApiKey.ts
+++ b/packages/vscode-extension/src/commands/setApiKey.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import { setSecretKey } from '../utils/secret-key-manager';
 import { API_KEY } from '../utils/constants';
+import { setSecretKey } from '../utils/secret-key-manager';
+import * as vscode from 'vscode';
 
 export const setApiKeyCommand = async (context: vscode.ExtensionContext) => {
   try {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,13 +1,13 @@
-import * as vscode from 'vscode';
-import { setApiKeyCommand } from './commands/setApiKey';
 import { scanSetTodosCommand } from './commands/scanSetTodos';
-import { setupProtectedClient } from './lib/api';
-import { clearSecretKey, getSecretKey } from './utils/secret-key-manager';
-import { API_KEY } from './utils/constants';
-import { OnboardingProvider } from './webviews/onboarding/onboarding-provider';
-import { shouldShowOnboarding } from './services/should-show-onboarding';
-import { TodosProvider } from './webviews/todos/todos-provider';
 import { sendTodosCommand } from './commands/sendTodos';
+import { setApiKeyCommand } from './commands/setApiKey';
+import { setupProtectedClient } from './lib/api';
+import { shouldShowOnboarding } from './services/should-show-onboarding';
+import { API_KEY } from './utils/constants';
+import { clearSecretKey, getSecretKey } from './utils/secret-key-manager';
+import { OnboardingProvider } from './webviews/onboarding/onboarding-provider';
+import { TodosProvider } from './webviews/todos/todos-provider';
+import * as vscode from 'vscode';
 
 //TODO: Fix the scaning and fetching
 export const activate = async (context: vscode.ExtensionContext) => {

--- a/packages/vscode-extension/src/lib/api.ts
+++ b/packages/vscode-extension/src/lib/api.ts
@@ -1,7 +1,7 @@
+import { API_KEY } from '../utils/constants';
+import { getSecretKey } from '../utils/secret-key-manager';
 import axios, { type InternalAxiosRequestConfig } from 'axios';
 import * as vscode from 'vscode';
-import { getSecretKey } from '../utils/secret-key-manager';
-import { API_KEY } from '../utils/constants';
 
 // const baseURL = process.env.API_URL || 'http://localhost:3000';
 const baseURL = 'http://localhost:3000/v1';

--- a/packages/vscode-extension/src/services/post-todos.ts
+++ b/packages/vscode-extension/src/services/post-todos.ts
@@ -1,5 +1,5 @@
-import { RawTodoBatch } from '@dev-dashboard/shared';
 import { todosApi } from '../apis/todos-api';
+import { RawTodoBatch } from '@dev-dashboard/shared';
 
 export const postTodos = async (todos: RawTodoBatch) => {
   try {

--- a/packages/vscode-extension/src/services/scan-todos.ts
+++ b/packages/vscode-extension/src/services/scan-todos.ts
@@ -1,5 +1,3 @@
-import * as vscode from 'vscode';
-import { ProcessedTodo, RawTodo } from '@dev-dashboard/shared';
 import {
   findPivotRoot,
   getSourceFiles,
@@ -7,6 +5,8 @@ import {
   tagTodos,
   scanFile,
 } from './scan';
+import { ProcessedTodo, RawTodo } from '@dev-dashboard/shared';
+import * as vscode from 'vscode';
 
 export const scanTodos = async (): Promise<{
   todos: ProcessedTodo[];

--- a/packages/vscode-extension/src/services/scan/find-pivot-root.ts
+++ b/packages/vscode-extension/src/services/scan/find-pivot-root.ts
@@ -1,5 +1,5 @@
-import path from 'path';
 import { findGitRoot } from '../../utils/repository-manager';
+import path from 'path';
 
 export const findPivotRoot = (
   workspacePath: string

--- a/packages/vscode-extension/src/services/scan/make-relative-path-todo.ts
+++ b/packages/vscode-extension/src/services/scan/make-relative-path-todo.ts
@@ -1,5 +1,5 @@
-import { RawTodo } from '@dev-dashboard/shared';
 import { makeRelativePath } from '../../utils/path-manager';
+import { RawTodo } from '@dev-dashboard/shared';
 
 export const makeRelativePathTodo = (
   todo: RawTodo,

--- a/packages/vscode-extension/src/services/scan/scan-file.ts
+++ b/packages/vscode-extension/src/services/scan/scan-file.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
 import { RawTodo } from '@dev-dashboard/shared';
+import * as fs from 'fs';
 
 export const scanFile = async (filePath: string): Promise<RawTodo[]> => {
   const todos: RawTodo[] = [];

--- a/packages/vscode-extension/src/services/should-show-onboarding.ts
+++ b/packages/vscode-extension/src/services/should-show-onboarding.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import { clearSecretKey, getSecretKey } from '../utils/secret-key-manager';
 import { API_KEY } from '../utils/constants';
+import { clearSecretKey, getSecretKey } from '../utils/secret-key-manager';
+import * as vscode from 'vscode';
 import z from 'zod';
 
 export const shouldShowOnboarding = async (

--- a/packages/vscode-extension/src/services/validate-api-key.ts
+++ b/packages/vscode-extension/src/services/validate-api-key.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
-import { API_KEY } from '../utils/constants';
 import { apiKeysApi } from '../apis/api-keys-api';
-import { setSecretKey } from '../utils/secret-key-manager';
 import { setupProtectedClient } from '../lib/api';
+import { API_KEY } from '../utils/constants';
+import { setSecretKey } from '../utils/secret-key-manager';
+import * as vscode from 'vscode';
 
 export const verifyApiKey = async (
   key: string,

--- a/packages/vscode-extension/src/utils/repository-manager.ts
+++ b/packages/vscode-extension/src/utils/repository-manager.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
 import { execSync } from 'child_process';
+import * as vscode from 'vscode';
 
 export const findGitRoot = (startPath: string): string | null => {
   try {

--- a/packages/vscode-extension/src/webviews/onboarding/onboarding-provider.ts
+++ b/packages/vscode-extension/src/webviews/onboarding/onboarding-provider.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
-import * as fs from 'fs';
-import z from 'zod';
-import { WebviewMessage } from './onboarding.type';
 import { verifyApiKey } from '../../services/validate-api-key';
+import { WebviewMessage } from './onboarding.type';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+import z from 'zod';
 
 export class OnboardingProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'devDashboardOnboarding';

--- a/packages/vscode-extension/src/webviews/onboarding/onboarding.html
+++ b/packages/vscode-extension/src/webviews/onboarding/onboarding.html
@@ -6,8 +6,8 @@
     <title>Onboarding</title>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="flex items-center justify-center min-h-screen">
-    <div class="w-full max-w-md p-8 space-y-6">
+  <body class="flex min-h-screen items-center justify-center">
+    <div class="w-full max-w-md space-y-6 p-8">
       <div class="text-center">
         <h2 class="text-2xl font-bold">Welcome to DevDashboard</h2>
       </div>
@@ -17,11 +17,11 @@
       </div>
 
       <form id="api-key-form" novalidate>
-        <div id="input-error-message" class="text-red-500 hidden"></div>
+        <div id="input-error-message" class="hidden text-red-500"></div>
         <div class="mb-6">
           <label
             for="api-key-input"
-            class="block mb-2 font-semibold text-inherit"
+            class="mb-2 block font-semibold text-inherit"
             >API Key</label
           >
           <input
@@ -29,16 +29,16 @@
             name="api-key"
             id="api-key-input"
             placeholder="Enter API Key..."
-            class="w-full border p-1 bg-inherit"
+            class="w-full border bg-inherit p-1"
           />
         </div>
 
-        <div id="submit-error-message" class="text-red-500 hidden mb-1"></div>
+        <div id="submit-error-message" class="mb-1 hidden text-red-500"></div>
         <div>
           <button
             type="submit"
             id="submit-button"
-            class="w-full p-1 bg-sky-600 text-white"
+            class="w-full bg-sky-600 p-1 text-white"
           >
             Submit and Verify
           </button>

--- a/packages/vscode-extension/src/webviews/todos/resolve-file-path.ts
+++ b/packages/vscode-extension/src/webviews/todos/resolve-file-path.ts
@@ -1,7 +1,7 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
-import { ProcessedTodo } from '@dev-dashboard/shared';
 import { findGitRoot } from '../../utils/repository-manager';
+import { ProcessedTodo } from '@dev-dashboard/shared';
+import * as path from 'path';
+import * as vscode from 'vscode';
 
 export const resolveFilePath = (
   todo: ProcessedTodo & { projectName?: string }

--- a/packages/vscode-extension/src/webviews/todos/todo-item.ts
+++ b/packages/vscode-extension/src/webviews/todos/todo-item.ts
@@ -1,7 +1,7 @@
-import * as vscode from 'vscode';
-import { ProcessedTodo } from '@dev-dashboard/shared';
 import { getIconForType } from './get-icon-for-type';
 import { resolveFilePath } from './resolve-file-path';
+import { ProcessedTodo } from '@dev-dashboard/shared';
+import * as vscode from 'vscode';
 
 export class TodoItem extends vscode.TreeItem {
   constructor(todo: ProcessedTodo) {

--- a/packages/vscode-extension/src/webviews/todos/todos-provider.ts
+++ b/packages/vscode-extension/src/webviews/todos/todos-provider.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import { ProcessedTodo } from '@dev-dashboard/shared';
 import { TodoItem } from './todo-item';
+import { ProcessedTodo } from '@dev-dashboard/shared';
+import * as vscode from 'vscode';
 
 export class TodosProvider implements vscode.TreeDataProvider<TodoItem> {
   private _onDidChangeTreeData: vscode.EventEmitter<


### PR DESCRIPTION
Consistently sort and group imports across all non-app files using Prettier's import plugin. This ensures readability, standardization, and eliminates noise in future diffs.